### PR TITLE
Update WPILib version and toolchain PPA

### DIFF
--- a/.compiler-download.sh
+++ b/.compiler-download.sh
@@ -3,7 +3,7 @@
 # Will download required packages for building
 dpkg-query -s frc-toolchain
 if [ $? = 1 ]; then
-	sudo apt-add-repository -y ppa:byteit101/frc-toolchain 
+	sudo apt-add-repository -y ppa:wpilib/toolchain 
 	sudo apt-get update -y
 	sudo apt-get install -y frc-toolchain
 fi

--- a/.wpilib-download.sh
+++ b/.wpilib-download.sh
@@ -11,7 +11,7 @@
 # rather than a hard coded file name.
 # The latest version can be determined from
 # http://first.wpi.edu/FRC/roborio/release/eclipse/site.xml
-version="0.1.0.201502241928"
+version="0.1.0.201601072029"
 
 source wpilib/version.txt
 if [ ! "$version" = "$downloaded_version" ] ; then


### PR DESCRIPTION
This fulfills https://github.com/Chantilly612Code/612-2016/issues/12 and https://github.com/Chantilly612Code/612-2016/issues/13, and updates the WPILib version and compiler PPA.