### PR TITLE
Update Travis to restrict deployment to tagged commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,6 @@ deploy:
   skip_cleanup: true
   on:
     repo: Chantilly612Code/612-2016
+    tags: true
 #    branch: travis
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,6 @@ deploy:
   on:
     repo: Chantilly612Code/612-2016
     tags: true
+    all_branches: true 
 #    branch: travis
 


### PR DESCRIPTION
This should fix deploying without a tagged commit.